### PR TITLE
Fix for the upper bound value

### DIFF
--- a/lib/consistent_hashing.js
+++ b/lib/consistent_hashing.js
@@ -64,7 +64,7 @@ ConsistentHashing.prototype.getNode = function(key) {
 
 
 ConsistentHashing.prototype.getNodePosition = function(hash) {
-  var upper = this.getRingLength();
+  var upper = this.getRingLength() - 1;
   var lower = 0;
   var idx   = 0;
 
@@ -84,7 +84,7 @@ ConsistentHashing.prototype.getNodePosition = function(hash) {
   }
 
   if (upper < 0) {
-    upper = this.getRingLength();
+    upper = this.getRingLength() - 1;
   }
 
   return upper;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consistent-hashing",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A pure JavaScript implementation of Consistent Hashing",
   "author": "Dai Akatsuka <d.akatsuka@gmail.com>",
   "main": "./index.js",


### PR DESCRIPTION
Hey,

I've fixed your consistent hashing library upper bound issue (ConsistentHashing.prototype.getNodePosition() was able to be equal to this.getRingLength() and in this case getNode methor returns undefined value).
Please, review the change.
## Thank you!

Vadim
