### PR TITLE
Faster way of counting keys in an object

### DIFF
--- a/lib/consistent_hashing.js
+++ b/lib/consistent_hashing.js
@@ -93,9 +93,7 @@ ConsistentHashing.prototype.getNodePosition = function(hash) {
 
 
 ConsistentHashing.prototype.getRingLength = function() {
-  var i = 0;
-  for (var key in this.ring) { i++ }
-  return i;
+  return Object.keys(this.ring).length;
 };
 
 


### PR DESCRIPTION
I ran some perf tests against your library. There was a bottleneck when counting the keys in this.ring, which I replaced. 

I loaded up one node and queried with two keys (100k times) and got the following results against your raw code:
1 node, 100k lookups: 4284ms
jamaica hashes to bar
pamaica hashes to bar
2 nodes, 100k lookups: 8136ms

Same machine, with this change:
1 node, 100k lookups: 259ms
jamaica hashes to bar
pamaica hashes to foo
2 nodes, 100k lookups: 262ms

enjoy!
