### PR TITLE
DRY Readme.md: refactored example to use only one logic path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ var chars = [
 chars.forEach(function(c) {
   var node = cons.getNode(c);
 
-  if (nodes[node]) {
-    nodes[node].push(c);
-  } else {
+  if (!nodes[node]) {
     nodes[node] = [];
-    nodes[node].push(c);
-  }
+  } 
+
+  nodes[node].push(c);
 });
 
 console.log(nodes);


### PR DESCRIPTION
Just a small improvement in the code displayed in the Readme file.
The goal was to not repeat the  `nodes[node].push(c);`, which in this case was necessary.